### PR TITLE
Updating the chrome-driver version/path/sha for ChromeDriver version 2.6

### DIFF
--- a/lib/chrome-driver.js
+++ b/lib/chrome-driver.js
@@ -6,7 +6,7 @@ var fs = require('fs')
 
 var platform
   , arch = '32'
-  , version = '2.2'
+  , version = '2.6'
 
 switch(process.platform){
   case 'darwin':
@@ -25,14 +25,14 @@ switch(process.platform){
 }
 
 var expectedSha = {
-  'linux32': '9f6bad3a1004cd983731a7b68c0a03f9c6b45696',
-  'linux64': 'c737452bacba963a36d32b3bc0fdb87cb6cb25a6',
-  'mac32': '8328d845afb2e5e124f38a2d72dbfc659c0936b0',
-  'win32': '7723028c78074144065d07566d77a4c2f19c390a'
+  'linux32': '50fa5c13e7e5a16704c1ea6a5951ddb9198c503b',
+  'linux64': 'cab1c61eea5397498f6a095fcbf726772554fb21',
+  'mac32': '4643652d403961dd9a9a1980eb1a06bf8b6e9bad',
+  'win32': '4196e08c591145fc51828e0a3045f35cb142c51f'
 }
 
-var filename = 'chromedriver_'+ platform + arch +'_'+ version +'.zip'
-  , url = 'https://chromedriver.googlecode.com/files/'+ filename
+var filename = 'chromedriver_'+ platform + arch +'.zip'
+  , url = 'http://chromedriver.storage.googleapis.com/'+ version +'/'+ filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
   , driver = path.join(path.dirname(__filename), '..', 'tmp', 'chromedriver')
 


### PR DESCRIPTION
@wookiehangover

Bumping this to chromedriver 2.6, which is the chromedriver version that works with OSX Mavericks.
Thanks for adding chromedriver to selenium-launcher!
