### PR TITLE
bump wd version so the tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "mocha": "1.x.x",
-    "wd": "0.0.34"
+    "wd": "0.2.5"
   },
   "engines": {
     "node": ">= 0.6.x"


### PR DESCRIPTION
Just wanted to bump the version of wd this depends on so that https://github.com/daaku/nodejs-selenium-launcher/pull/8 will be marked green.
