### PR TITLE
Selenium updates

### DIFF
--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -9,10 +9,11 @@ var fs = require('fs')
   , chromeDriver = require('./chrome-driver')
 
 var override = process.env.SELENIUM_VERSION ? process.env.SELENIUM_VERSION.split(':') : []
-  , version = override[0] || '2.39.0'
-  , expectedSha = override[1] || 'f2391600481dd285002d04b66916fc4286ff70ce'
+  , version = override[0] || '2.42.2'
+  , majorMinorVersion = version.split('.').slice(0, 2).join('.')
+  , expectedSha = override[1] || '921005b6628821c9a29de6358917a82d1e3dfa94'
   , filename = 'selenium-server-standalone-' + version + '.jar'
-  , url = 'http://selenium.googlecode.com/files/' + filename
+  , url = 'http://selenium-release.storage.googleapis.com/' + majorMinorVersion + '/' + filename
   , outfile = path.join(path.dirname(__filename), '..', 'tmp', filename)
 
 function download(cb) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-launcher",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/daaku/nodejs-selenium-launcher",
   "author": "Naitik Shah <n@daaku.org>",
   "main": "lib/selenium-launcher",

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ You can override the selenium server version used by the launcer
  via the environment variable
 
 ```bash
-SELENIUM_VERSION=2.32.0:c94e6d5392b687d3a141a35f5a489f50f01bef6a node app.js
+SELENIUM_VERSION=2.39.0:5a8742d5ba1c3d10339541520fead7e7f50712db node app.js
 ```
 
 You'll have to supply a valid sha for the version.


### PR DESCRIPTION
This PR contains the following updates.
- Update to latest selenium version (2.4.2)
- Update selenium download URL, as it has changed.  See [this note](https://code.google.com/p/selenium/downloads/detail?name=downloads_location&can=2&q=).
- Update readme example, since the 2.32.0 version used in previous example is not available at the new download location
- Bump version - Bumped minor rather than patch version as this is a potentially breaking change.  The new selenium download location only stores versions 2.39 and newer.

_NOTE:  This PR could be modified to support the old download location as well, if you feel there is value in keeping legacy support intact._
